### PR TITLE
Create Pattern Demo controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This document details all notable changes to the Empty Style Guide framework. It
 
 ### Added
 
+- Styles to use flexbox layout for the pattern demo meta layout.
 - Create standard and secondary button styles.
 - Reset button in the pattern demo to reset the demo container width to the viewport size or the max, whichever is smaller.
 - Buttons in the pattern demo section to control changing its width.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ This document details all notable changes to the Empty Style Guide framework. It
 
 ## 0.7.0 (2018-04-10)
 
+### Changed
+
+- Revise order of the pattern demo meta and controllers to facilitate flexbox layout.
+
 ### Added
 
+- Reset button in the pattern demo to reset the demo container width to the viewport size or the max, whichever is smaller.
+- Buttons in the pattern demo section to control changing its width.
 - Date yaml file for storing user's preferred breakpoints for the demo container width controller.
 
 ## 0.6.1 (2018-04-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ This document details all notable changes to the Empty Style Guide framework. It
 
 ### Changed
 
+- Refactor demo container controller event listeners.
 - Convert default button into a mixin.
 - Revise order of the pattern demo meta and controllers to facilitate flexbox layout.
 
 ### Added
 
+- JavaScript controllers to manage the width of the pattern demo container.
 - Styles to use flexbox layout for the pattern demo meta layout.
 - Create standard and secondary button styles.
 - Reset button in the pattern demo to reset the demo container width to the viewport size or the max, whichever is smaller.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This document details all notable changes to the Empty Style Guide framework. It
 ### Removed (for deprecated features removed in this release)
 -->
 
+## 0.7.0 (2018-04-10)
+
+### Added
+
+- Date yaml file for storing user's preferred breakpoints for the demo container width controller.
+
 ## 0.6.1 (2018-04-02)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ This document details all notable changes to the Empty Style Guide framework. It
 
 ### Changed
 
+- Convert default button into a mixin.
 - Revise order of the pattern demo meta and controllers to facilitate flexbox layout.
 
 ### Added
 
+- Create standard and secondary button styles.
 - Reset button in the pattern demo to reset the demo container width to the viewport size or the max, whichever is smaller.
 - Buttons in the pattern demo section to control changing its width.
 - Date yaml file for storing user's preferred breakpoints for the demo container width controller.

--- a/_data/breakpoints.yml
+++ b/_data/breakpoints.yml
@@ -1,0 +1,10 @@
+# Define your breakpoints here.
+#
+# Define sizes in pixels.
+
+- name: small
+  size: 320
+- name: medium
+  size: 640
+- name: large
+  size: 1024

--- a/_includes/pattern-styles.html
+++ b/_includes/pattern-styles.html
@@ -4,6 +4,11 @@
         contain: content;
         display: block;
         font: 14px/22px "Open Sans", "Lucida Grande", "Lucida Sans", Geneva, Verdana, sans-serif;
+        transition-delay: .1s;
+        transition-duration: .3s;
+        transition-property: width;
+        transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+        width: 100%;
     }
     .pattern-inner {
         margin: 1rem;

--- a/_includes/pattern-styles.html
+++ b/_includes/pattern-styles.html
@@ -1,6 +1,7 @@
 <style type="text/css">
     :host {
-        border: 1px solid lightblue;
+        border-top: 1px dotted #bd93f9;
+        border-bottom: 1px dotted #bd93f9;
         contain: content;
         display: block;
         font: 14px/22px "Open Sans", "Lucida Grande", "Lucida Sans", Geneva, Verdana, sans-serif;
@@ -9,9 +10,6 @@
         transition-property: width;
         transition-timing-function: cubic-bezier(.4, 0, .2, 1);
         width: 100%;
-    }
-    .pattern-inner {
-        margin: 1rem;
     }
     .ui--tiles {
         align-items: flex-start;

--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -27,6 +27,13 @@ layout: default
 
     <section class="pattern-demo">
         <h2>Demo</h2>
+        <label for="pattern-demo-width">Width (pixels):</label>
+        <input id="pattern-demo-width" type="number" min="0" max="999999" value="" step="1" name="demoWidth" pattern="\d+">
+<!-- for max customizability, these should be generated as a foreach built from a data object -->
+{%- assign breakpoint = '630' -%}
+{%- assign bpname = 'medium' -%}
+<!-- <button class="pattern-demo-width-setter" type="button" value="{{ breakpoint }}">Set to {{ breakpoint }}</button>
+<button class="pattern-demo-width-setter" type="button" value="1200">Set to 1200</button> -->
         <template id="pattern-demo">
             {%- include pattern-styles.html -%}
             <div class="pattern-inner">

--- a/_layouts/pattern.html
+++ b/_layouts/pattern.html
@@ -26,14 +26,17 @@ layout: default
     </section>
 
     <section class="pattern-demo">
-        <h2>Demo</h2>
-        <label for="pattern-demo-width">Width (pixels):</label>
-        <input id="pattern-demo-width" type="number" min="0" max="999999" value="" step="1" name="demoWidth" pattern="\d+">
-<!-- for max customizability, these should be generated as a foreach built from a data object -->
-{%- assign breakpoint = '630' -%}
-{%- assign bpname = 'medium' -%}
-<!-- <button class="pattern-demo-width-setter" type="button" value="{{ breakpoint }}">Set to {{ breakpoint }}</button>
-<button class="pattern-demo-width-setter" type="button" value="1200">Set to 1200</button> -->
+        <div class="pattern-demo-meta">
+            <h2>Demo</h2>
+            <div class="width-freeform">
+                <label for="pattern-demo-width">Width (pixels):</label>
+                <input id="pattern-demo-width" type="number" min="0" max="9999" value="" step="1" name="demoWidth" pattern="\d+">
+            </div>
+            {%- for bp in site.data.breakpoints -%}
+                <button class="set-pattern-width" type="button" value="{{ bp.size }}">{{ bp.name | capitalize }}</button>
+            {%- endfor -%}
+            <button class="button-secondary" id="reset-width">Reset</button>
+        </div>
         <template id="pattern-demo">
             {%- include pattern-styles.html -%}
             <div class="pattern-inner">

--- a/_sass/partials/_base.scss
+++ b/_sass/partials/_base.scss
@@ -113,12 +113,49 @@ blockquote {
 /**
  * Buttons
  */
-button {
+%button {
     background: transparent center center no-repeat;
     border: 0;
     cursor: pointer;
     display: block;
     overflow: hidden;
+
+    &:hover,
+    &:focus {
+        background: lighten($grey-color-light, 5%);
+    }
+
+}
+
+button,
+.button {
+    @extend %button;
+
+    main & {
+        background: $dt-gray-dark;
+        border-radius: 4px;
+        box-shadow: 1px 1px 3px 1px rgba(20, 20, 20, 0.3);
+        color: $dt-gray-light;
+        font-size: 1rem;
+        margin: .5em;
+        padding: .75em 1em;
+
+        &:hover,
+        &:focus {
+            background: $dt-purple;
+            box-shadow: 1px 1px 5px 2px rgba(20, 20, 20, 0.3);
+            color: $text-color;
+        }
+    }
+}
+
+.button-secondary {
+
+    main & {
+        background: #fff;
+        border: 1px solid $dt-gray-dark;
+        color: $text-color;
+    }
 }
 
 /**

--- a/_sass/partials/_layout.scss
+++ b/_sass/partials/_layout.scss
@@ -70,6 +70,7 @@ article {
     background: #fff;
     border-radius: 0 5px 5px 0;
     box-shadow: 2px 3px 5px 1px rgba(20, 20, 20, .2);
+    @extend %button;
     height: 3.5rem;
     position: fixed;
     top: 1.5rem;
@@ -83,7 +84,6 @@ article {
 
     &:hover,
     &:focus {
-        background: #efefef;
         box-shadow: 2px 3px 7px 3px rgba(20, 20, 20, .2);
     }
 
@@ -302,6 +302,40 @@ nav {
 .post-link {
     display: block;
     @include relative-font-size(1.5);
+}
+
+/**
+ * Patterns
+ */
+.pattern-demo-meta {
+    align-items: center;
+    display: flex;
+    justify-content: flex-end;
+
+    h2 {
+        margin-right: auto;
+    }
+
+    label,
+    input {
+        font-size: 1.3rem;
+        line-height: 1.3;
+    }
+
+    input[type="number"],
+    input[type="text"] {
+        border: 1px solid $dt-gray-dark;
+        margin-right: 1rem;
+        padding-left: .25em;
+
+        &:focus {
+            background: lighten($dt-pink, 21%);
+        }
+    }
+}
+
+.pattern-inner {
+    margin: 1rem;
 }
 
 /**

--- a/assets/js/patterns.js
+++ b/assets/js/patterns.js
@@ -64,4 +64,49 @@ Array.from(navtitles).forEach(function(navtitle) {
 
     });
 
+    let demoInput = document.getElementById('pattern-demo-width');
+    let demoContainer = document.querySelector('pattern-demo');
+    let demoWidthSetters = document.getElementsByClassName('pattern-demo-width-setter');
+
+    function getWidth(e) {
+        return e.clientWidth;
+    }
+
+    function getValue(e) {
+        return e.value;
+    }
+
+    function updateWidthValue(item) {
+        item.value = getWidth(document.querySelector('pattern-demo'));
+    }
+
+    function resizeDemoContainer(item, width) {
+        item.style.width = width + "px"
+    }
+
+    // First populate the demo width input value with its base value.
+    updateWidthValue(demoInput);
+
+    demoInput.addEventListener('mouseup', function() {
+        var newValue = getValue(demoInput);
+        resizeDemoContainer(demoContainer, newValue);
+        updateWidthValue(demoInput);
+    } );
+
+    demoInput.addEventListener('keyup', function(e) {
+        if (e.key === 'Enter') {
+            var newValue = getValue(demoInput);
+            resizeDemoContainer(demoContainer, newValue);
+            updateWidthValue(demoInput);
+        }
+    }, false );
+
+    // Array.from(demoWidthSetters).forEach(function(set) {
+    //     set.addEventListener('mouseup', function() {
+    //         var newValue = getValue(set);
+    //         resizeDemoContainer(demoContainer, newValue);
+    //         updateWidthValue(newValue);
+    //     }, false);
+    // } );
+
 })();

--- a/assets/js/patterns.js
+++ b/assets/js/patterns.js
@@ -66,15 +66,10 @@ Array.from(navtitles).forEach(function(navtitle) {
 
     var demoInput, resetButton, demoContainer, demoWidthSetters;
 
-    const baseContainerWidth = getWidth(document.querySelector('pattern-demo'));
-
     demoInput = document.getElementById('pattern-demo-width');
     resetButton = document.getElementById('reset-width');
     demoContainer = document.querySelector('pattern-demo');
-    demoWidthSetters = document.getElementsByClassName('pattern-demo-width-setter');
-
-    // Set base input controller value.
-    demoInput.value = baseContainerWidth;
+    demoWidthSetters = document.getElementsByClassName('set-pattern-width');
 
     function getWidth(e) {
         return e.clientWidth;
@@ -84,59 +79,99 @@ Array.from(navtitles).forEach(function(navtitle) {
         return e.value;
     }
 
-    function resizeDemoContainer() {
-        demoContainer.style.width = getValue(demoInput) + 'px';
+    function updateInputValue() {
+        demoInput.value = getWidth(demoContainer);
     }
 
-    var smallBreakpoint = 800;
+    function resizeDemoContainer(width = null) {
+        if ( ! width ) {
+            demoContainer.style.width = getValue(demoInput) + 'px';
+        } else if ( "number" === typeof width ) {
+            demoContainer.style.width = width + 'px';
+        } else {
+            console.log('Invalid width input: Must be a number.');
+            return;
+        }
+    }
 
     var resize = {
-        reset: baseContainerWidth,
+        update: true,
         demoContainer: function() {
-            if ( undefined !== this.reset ) {
-                demoContainer.style.width = this.reset + 'px';
-                demoInput.value = this.reset;
-            } else if ( "live" == this ) {
+            if ( undefined !== this.update ) {
                 resizeDemoContainer();
-            } else if ( "smallBp" == this ) {
-                demoContainer.style.width = smallBreakpoint + 'px';
-                demoInput.value = smallBreakpoint;
+            } else if ( "reset" == this ) {
+                demoContainer.removeAttribute('style');
+                setTimeout(updateInputValue, 500);
             } else {
-                console.log('Please enter a valid resize.demoContainer parameter.');
+                console.log(this);
+                var num = parseInt(this, 10);
+                if (isNaN(num)) { num = 'error' }
+                resizeDemoContainer(num);
+                setTimeout(updateInputValue, 500);
             }
         }
     };
 
-    // Refactor these like the ones below.
-    demoInput.addEventListener('mouseup', resize.demoContainer.bind("live", resize), false );
-    demoInput.addEventListener('blur', resize.demoContainer.bind("live", resize), false );
-    demoInput.addEventListener('keyup', function(e) {
-        if (e.key === 'Enter') {
-            resizeDemoContainer();
-        }
-    }, false );
+    // Set base input controller value to container width.
+    updateInputValue();
 
-    resetButton.addEventListener(
+    // Update the input value to match if the user resizes the window.
+    window.addEventListener('resize', updateInputValue, false);
+
+    /*
+     * Handles the width input field.
+     *
+     * @todo Refactor these like the ones below.
+     */
+    demoInput.addEventListener(
         'mouseup',
         resize.demoContainer.bind(resize),
+        false
+    );
+
+    demoInput.addEventListener(
+        'blur',
+        resize.demoContainer.bind(resize),
+        false
+    );
+
+    demoInput.addEventListener(
+        'keyup', function(e) {
+            if (e.key === 'Enter') {
+                resizeDemoContainer();
+            }
+        },
+        false
+    );
+
+    /*
+     * Handles the reset button.
+     *
+     * These set the window size and input to current view.
+     */
+    resetButton.addEventListener(
+        'mouseup',
+        resize.demoContainer.bind('reset', resize),
         false
     );
 
     resetButton.addEventListener(
         'keyup', function(e) {
             if ( 'Enter' === e.key) {
-                resize.demoContainer();
+                var doResize = resize.demoContainer.bind('reset', resize);
+                doResize();
             }
         },
         false
     );
 
-    // Array.from(demoWidthSetters).forEach(function(set) {
-    //     set.addEventListener('mouseup', function() {
-    //         var newValue = getValue(set);
-    //         resizeDemoContainer(demoContainer, newValue);
-    //         setWidthInputValue(newValue);
-    //     }, false);
-    // } );
+    Array.from(demoWidthSetters).forEach(function(e) {
+        console.log(e.value);
+        e.addEventListener(
+            'mouseup',
+            resize.demoContainer.bind(e.value, resize),
+            false
+        );
+    } );
 
 })();

--- a/assets/js/patterns.js
+++ b/assets/js/patterns.js
@@ -64,9 +64,17 @@ Array.from(navtitles).forEach(function(navtitle) {
 
     });
 
-    let demoInput = document.getElementById('pattern-demo-width');
-    let demoContainer = document.querySelector('pattern-demo');
-    let demoWidthSetters = document.getElementsByClassName('pattern-demo-width-setter');
+    var demoInput, resetButton, demoContainer, demoWidthSetters;
+
+    const baseContainerWidth = getWidth(document.querySelector('pattern-demo'));
+
+    demoInput = document.getElementById('pattern-demo-width');
+    resetButton = document.getElementById('reset-width');
+    demoContainer = document.querySelector('pattern-demo');
+    demoWidthSetters = document.getElementsByClassName('pattern-demo-width-setter');
+
+    // Set base input controller value.
+    demoInput.value = baseContainerWidth;
 
     function getWidth(e) {
         return e.clientWidth;
@@ -76,36 +84,58 @@ Array.from(navtitles).forEach(function(navtitle) {
         return e.value;
     }
 
-    function updateWidthValue(item) {
-        item.value = getWidth(document.querySelector('pattern-demo'));
+    function resizeDemoContainer() {
+        demoContainer.style.width = getValue(demoInput) + 'px';
     }
 
-    function resizeDemoContainer(item, width) {
-        item.style.width = width + "px"
-    }
+    var smallBreakpoint = 800;
 
-    // First populate the demo width input value with its base value.
-    updateWidthValue(demoInput);
+    var resize = {
+        reset: baseContainerWidth,
+        demoContainer: function() {
+            if ( undefined !== this.reset ) {
+                demoContainer.style.width = this.reset + 'px';
+                demoInput.value = this.reset;
+            } else if ( "live" == this ) {
+                resizeDemoContainer();
+            } else if ( "smallBp" == this ) {
+                demoContainer.style.width = smallBreakpoint + 'px';
+                demoInput.value = smallBreakpoint;
+            } else {
+                console.log('Please enter a valid resize.demoContainer parameter.');
+            }
+        }
+    };
 
-    demoInput.addEventListener('mouseup', function() {
-        var newValue = getValue(demoInput);
-        resizeDemoContainer(demoContainer, newValue);
-        updateWidthValue(demoInput);
-    } );
-
+    // Refactor these like the ones below.
+    demoInput.addEventListener('mouseup', resize.demoContainer.bind("live", resize), false );
+    demoInput.addEventListener('blur', resize.demoContainer.bind("live", resize), false );
     demoInput.addEventListener('keyup', function(e) {
         if (e.key === 'Enter') {
-            var newValue = getValue(demoInput);
-            resizeDemoContainer(demoContainer, newValue);
-            updateWidthValue(demoInput);
+            resizeDemoContainer();
         }
     }, false );
+
+    resetButton.addEventListener(
+        'mouseup',
+        resize.demoContainer.bind(resize),
+        false
+    );
+
+    resetButton.addEventListener(
+        'keyup', function(e) {
+            if ( 'Enter' === e.key) {
+                resize.demoContainer();
+            }
+        },
+        false
+    );
 
     // Array.from(demoWidthSetters).forEach(function(set) {
     //     set.addEventListener('mouseup', function() {
     //         var newValue = getValue(set);
     //         resizeDemoContainer(demoContainer, newValue);
-    //         updateWidthValue(newValue);
+    //         setWidthInputValue(newValue);
     //     }, false);
     // } );
 


### PR DESCRIPTION
Creates and styles JavaScript controllers for user inputs allowing variably adjusting the width of the pattern demo container to see the pattern library items at different widths. Includes:

* A number-style text input field that accepts any number and resized the pattern container to match.
* A resize event listener to update the input field to reflect the actual width of the window (when not locked by manually setting it).
* A data file in the `data` directory to store any number of pre-defined breakpoints (identified by name and size), which automatically create buttons in the pattern demo controller.
* A reset button that resets the pattern demo container width to the current viewport width or the containers max width (whichever is smaller).